### PR TITLE
templates/actions.tpl: add throws tag for commonly thrown actionException in bind()

### DIFF
--- a/src/apps/mpcmfConsole/library/codeManager/entityManager/templates/actions.tpl
+++ b/src/apps/mpcmfConsole/library/codeManager/entityManager/templates/actions.tpl
@@ -4,6 +4,7 @@
 namespace {$entityData['moduleNamespace']}\actions;
 
 use mpcmf\modules\moduleBase\actions\actionsBase;
+use mpcmf\modules\moduleBase\exceptions\actionException;
 use mpcmf\system\pattern\singleton;
 
 /**
@@ -43,6 +44,7 @@ class {$data['className']}
      * Bind some custom actions
      *
      * @return mixed
+     * @throws actionException
      */
     public function bind()
     {


### PR DESCRIPTION
The bind method in an actionsBase class usually looks something like this:

```
$this->registerAction('actionName.doSomething', new action([...], $this));
```

Both registerAction and new action can throw an `actionException`, so it might be useful to include a `@throws` tag by default.
Although, if the method stays empty, the `@throws` tag would not make sense.
As I don't know how often the bind() method will stay empty vs how often it will get code, you should decide whether this is useful or not :)

(In the end, I only did this to maybe get less warnings from PhpStorm in the future, and it has no actual impact on functionality :D)